### PR TITLE
feat(async search): format aggregations with timeseries

### DIFF
--- a/internal/api/seqapi/v1/http/aggregation_ts.go
+++ b/internal/api/seqapi/v1/http/aggregation_ts.go
@@ -83,14 +83,16 @@ func (a *API) serveGetAggregationTs(w http.ResponseWriter, r *http.Request) {
 
 type aggregationTsQuery struct {
 	aggregationQuery
-	Interval string `json:"interval" format:"duration" example:"1m"`
+	Interval string `json:"interval,omitempty" format:"duration" example:"1m"`
 } //	@name	seqapi.v1.AggregationTsQuery
 
 func (aq aggregationTsQuery) toProto() *seqapi.AggregationQuery {
 	q := aq.aggregationQuery.toProto()
 
-	q.Interval = new(string)
-	*q.Interval = aq.Interval
+	if aq.Interval != "" {
+		q.Interval = new(string)
+		*q.Interval = aq.Interval
+	}
 
 	return q
 }

--- a/internal/api/seqapi/v1/http/get_async_searches_list.go
+++ b/internal/api/seqapi/v1/http/get_async_searches_list.go
@@ -170,23 +170,29 @@ func startAsyncSearchRequestFromProto(r *seqapi.StartAsyncSearchRequest) startAs
 		Query:        r.Query,
 		From:         r.From.AsTime(),
 		To:           r.To.AsTime(),
-		Aggregations: aggregationQueriesFromProto(r.Aggs),
+		Aggregations: aggregationTsQueriesFromProto(r.Aggs),
 		Histogram:    hist,
 		WithDocs:     r.WithDocs,
 		Size:         r.Size,
 	}
 }
 
-func aggregationQueriesFromProto(aggs []*seqapi.AggregationQuery) aggregationQueries {
-	result := make(aggregationQueries, 0, len(aggs))
+func aggregationTsQueriesFromProto(aggs []*seqapi.AggregationQuery) aggregationTsQueries {
+	result := make(aggregationTsQueries, 0, len(aggs))
 
 	for _, agg := range aggs {
-		result = append(result, aggregationQuery{
-			Field:     agg.Field,
-			GroupBy:   agg.GroupBy,
-			Func:      aggregationFuncFromProto(agg.Func),
-			Quantiles: agg.Quantiles,
-		})
+		q := aggregationTsQuery{
+			aggregationQuery: aggregationQuery{
+				Field:     agg.Field,
+				GroupBy:   agg.GroupBy,
+				Func:      aggregationFuncFromProto(agg.Func),
+				Quantiles: agg.Quantiles,
+			},
+		}
+		if agg.Interval != nil {
+			q.Interval = *agg.Interval
+		}
+		result = append(result, q)
 	}
 
 	return result

--- a/internal/api/seqapi/v1/http/get_async_searches_list_test.go
+++ b/internal/api/seqapi/v1/http/get_async_searches_list_test.go
@@ -87,9 +87,10 @@ func TestServeGetAsyncSearchesList(t *testing.T) {
 								To:        timestamppb.New(mockTime),
 								Aggs: []*seqapi.AggregationQuery{
 									{
-										Field:   "x",
-										GroupBy: "level",
-										Func:    seqapi.AggFunc_AGG_FUNC_AVG,
+										Field:    "x",
+										GroupBy:  "level",
+										Func:     seqapi.AggFunc_AGG_FUNC_AVG,
+										Interval: pointerTo("30s"),
 									},
 								},
 								Hist: &seqapi.StartAsyncSearchRequest_HistQuery{
@@ -121,7 +122,7 @@ func TestServeGetAsyncSearchesList(t *testing.T) {
 				},
 				searchIDs: []string{mockSearchID1, mockSearchID2},
 			},
-			wantRespBody: `{"searches":[{"search_id":"c9a34cf8-4c66-484e-9cc2-42979d848656","status":"done","request":{"retention":"seconds:60","query":"message:error","from":"2025-08-06T17:37:12.000000123Z","to":"2025-08-06T17:52:12.000000123Z","with_docs":true,"size":100},"started_at":"2025-08-06T17:51:42.000000123Z","expires_at":"2025-08-06T17:52:42.000000123Z","progress":1,"disk_usage":"512","owner_name":"some_user_1","error":"some error"},{"search_id":"9e4c068e-d4f4-4a5d-be27-a6524a70d70d","status":"canceled","request":{"retention":"seconds:360","query":"message:error and level:3","from":"2025-08-06T16:52:12.000000123Z","to":"2025-08-06T17:52:12.000000123Z","aggregations":[{"field":"x","group_by":"level","agg_func":"avg"}],"histogram":{"interval":"1s"},"with_docs":false,"size":0},"started_at":"2025-08-06T17:51:12.000000123Z","expires_at":"2025-08-06T17:57:12.000000123Z","canceled_at":"2025-08-06T17:52:12.000000123Z","progress":1,"disk_usage":"256","owner_name":"some_user_2"}]}`,
+			wantRespBody: `{"searches":[{"search_id":"c9a34cf8-4c66-484e-9cc2-42979d848656","status":"done","request":{"retention":"seconds:60","query":"message:error","from":"2025-08-06T17:37:12.000000123Z","to":"2025-08-06T17:52:12.000000123Z","with_docs":true,"size":100},"started_at":"2025-08-06T17:51:42.000000123Z","expires_at":"2025-08-06T17:52:42.000000123Z","progress":1,"disk_usage":"512","owner_name":"some_user_1","error":"some error"},{"search_id":"9e4c068e-d4f4-4a5d-be27-a6524a70d70d","status":"canceled","request":{"retention":"seconds:360","query":"message:error and level:3","from":"2025-08-06T16:52:12.000000123Z","to":"2025-08-06T17:52:12.000000123Z","aggregations":[{"field":"x","group_by":"level","agg_func":"avg","interval":"30s"}],"histogram":{"interval":"1s"},"with_docs":false,"size":0},"started_at":"2025-08-06T17:51:12.000000123Z","expires_at":"2025-08-06T17:57:12.000000123Z","canceled_at":"2025-08-06T17:52:12.000000123Z","progress":1,"disk_usage":"256","owner_name":"some_user_2"}]}`,
 			wantStatus:   http.StatusOK,
 		},
 		{

--- a/internal/api/seqapi/v1/http/start_async_search_test.go
+++ b/internal/api/seqapi/v1/http/start_async_search_test.go
@@ -34,7 +34,7 @@ func TestServeStartAsyncSearch(t *testing.T) {
 	to := from.Add(time.Second)
 
 	formatReqBody := func(retention string) string {
-		return fmt.Sprintf(`{"retention":%q,"query":%q,"from":%q,"to":%q,"with_docs":true,"size":100,"meta":"{\"some\":\"meta\"}","histogram":{"interval":"1s"},"aggregations":[{"field":"v","group_by":"level","agg_func":"avg","quantiles":[0.95]}]}`,
+		return fmt.Sprintf(`{"retention":%q,"query":%q,"from":%q,"to":%q,"with_docs":true,"size":100,"meta":"{\"some\":\"meta\"}","histogram":{"interval":"1s"},"aggregations":[{"field":"v","group_by":"level","agg_func":"avg","quantiles":[0.95],"interval":"30s"}]}`,
 			retention, query, from.Format(time.RFC3339), to.Format(time.RFC3339))
 	}
 
@@ -80,6 +80,7 @@ func TestServeStartAsyncSearch(t *testing.T) {
 							GroupBy:   "level",
 							Func:      seqapi.AggFunc_AGG_FUNC_AVG,
 							Quantiles: []float64{0.95},
+							Interval:  pointerTo("30s"),
 						},
 					},
 					Meta: meta,

--- a/internal/pkg/client/seqdb/grpc_types.go
+++ b/internal/pkg/client/seqdb/grpc_types.go
@@ -467,6 +467,7 @@ func newSeqapiAggQuerySlice(aggs []*seqproxyapi.AggQuery) []*seqapi.AggregationQ
 			GroupBy:   agg.GroupBy,
 			Func:      seqapi.AggFunc(agg.Func),
 			Quantiles: agg.Quantiles,
+			Interval:  agg.Interval,
 		})
 	}
 

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2050,6 +2050,42 @@
                 }
             }
         },
+        "seqapi.v1.AsyncSearchResponse": {
+            "type": "object",
+            "properties": {
+                "aggregations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/seqapi.v1.Aggregation"
+                    }
+                },
+                "aggregations_ts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/seqapi.v1.AggregationTs"
+                    }
+                },
+                "error": {
+                    "$ref": "#/definitions/seqapi.v1.Error"
+                },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/seqapi.v1.Event"
+                    }
+                },
+                "histogram": {
+                    "$ref": "#/definitions/seqapi.v1.Histogram"
+                },
+                "partialResponse": {
+                    "type": "boolean"
+                },
+                "total": {
+                    "type": "string",
+                    "format": "int64"
+                }
+            }
+        },
         "seqapi.v1.AsyncSearchStatus": {
             "type": "string",
             "enum": [
@@ -2257,7 +2293,7 @@
                     "$ref": "#/definitions/seqapi.v1.StartAsyncSearchRequest"
                 },
                 "response": {
-                    "$ref": "#/definitions/seqapi.v1.SearchResponse"
+                    "$ref": "#/definitions/seqapi.v1.AsyncSearchResponse"
                 },
                 "started_at": {
                     "type": "string",
@@ -2601,7 +2637,7 @@
                 "aggregations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/seqapi.v1.AggregationQuery"
+                        "$ref": "#/definitions/seqapi.v1.AggregationTsQuery"
                     }
                 },
                 "from": {


### PR DESCRIPTION
# Description

aggs with timeseries in async searches now in the same format as in `/aggregation_ts` method