### PR TITLE
fix(aggregation_ts): return error as object with code and message

### DIFF
--- a/internal/api/seqapi/v1/http/aggregation_ts.go
+++ b/internal/api/seqapi/v1/http/aggregation_ts.go
@@ -222,7 +222,7 @@ func aggregationsTsFromProto(proto []*seqapi.Aggregation, reqAggs aggregationTsQ
 
 type getAggregationTsResponse struct {
 	Aggregations aggregationsTs `json:"aggregations"`
-	Error        string         `json:"error,omitempty"`
+	Error        apiError       `json:"error"`
 } //	@name	seqapi.v1.GetAggregationTsResponse
 
 func getAggregationTsResponseFromProto(proto *seqapi.GetAggregationResponse, reqAggs aggregationTsQueries) getAggregationTsResponse {
@@ -231,9 +231,7 @@ func getAggregationTsResponseFromProto(proto *seqapi.GetAggregationResponse, req
 	}
 	r := getAggregationTsResponse{
 		Aggregations: aggregationsTsFromProto(proto.Aggregations, reqAggs),
-	}
-	if proto.Error != nil {
-		r.Error = proto.Error.Message
+		Error:        apiErrorFromProto(proto.GetError()),
 	}
 	return r
 }

--- a/internal/api/seqapi/v1/http/aggregation_ts_test.go
+++ b/internal/api/seqapi/v1/http/aggregation_ts_test.go
@@ -98,7 +98,7 @@ func TestServeGetAggregationTs(t *testing.T) {
 					},
 				},
 			},
-			wantRespBody: `{"aggregations":[{"data":{"result":[{"metric":{"test_count1":"test1"},"values":[{"timestamp":1695637231,"value":1}]},{"metric":{"test_count1":"test2"},"values":[{"timestamp":1695637232,"value":2}]},{"metric":{"test_count1":"test3"},"values":[{"timestamp":1695637233,"value":3}]}]}},{"data":{"result":[{"metric":{"test_count2":"test1"},"values":[{"timestamp":1695637231,"value":1}]},{"metric":{"test_count2":"test2"},"values":[{"timestamp":1695637232,"value":2}]},{"metric":{"test_count2":"test3"},"values":[{"timestamp":1695637233,"value":3}]}]}}]}`,
+			wantRespBody: `{"aggregations":[{"data":{"result":[{"metric":{"test_count1":"test1"},"values":[{"timestamp":1695637231,"value":1}]},{"metric":{"test_count1":"test2"},"values":[{"timestamp":1695637232,"value":2}]},{"metric":{"test_count1":"test3"},"values":[{"timestamp":1695637233,"value":3}]}]}},{"data":{"result":[{"metric":{"test_count2":"test1"},"values":[{"timestamp":1695637231,"value":1}]},{"metric":{"test_count2":"test2"},"values":[{"timestamp":1695637232,"value":2}]},{"metric":{"test_count2":"test3"},"values":[{"timestamp":1695637233,"value":3}]}]}}],"error":{"code":"ERROR_CODE_NO"}}`,
 			wantStatus:   http.StatusOK,
 			cfg: config.SeqAPI{
 				MaxAggregationsPerRequest:  3,
@@ -155,7 +155,7 @@ func TestServeGetAggregationTs(t *testing.T) {
 					},
 				},
 			},
-			wantRespBody: `{"aggregations":[{"data":{"result":[{"metric":{"quantile":"p95","service":"test1"},"values":[{"timestamp":1695637231,"value":100}]},{"metric":{"quantile":"p99","service":"test1"},"values":[{"timestamp":1695637231,"value":150}]},{"metric":{"quantile":"p95","service":"test2"},"values":[{"timestamp":1695637232,"value":100}]},{"metric":{"quantile":"p99","service":"test2"},"values":[{"timestamp":1695637232,"value":150}]},{"metric":{"quantile":"p95","service":"test3"},"values":[{"timestamp":1695637233,"value":100}]},{"metric":{"quantile":"p99","service":"test3"},"values":[{"timestamp":1695637233,"value":150}]}]}}]}`,
+			wantRespBody: `{"aggregations":[{"data":{"result":[{"metric":{"quantile":"p95","service":"test1"},"values":[{"timestamp":1695637231,"value":100}]},{"metric":{"quantile":"p99","service":"test1"},"values":[{"timestamp":1695637231,"value":150}]},{"metric":{"quantile":"p95","service":"test2"},"values":[{"timestamp":1695637232,"value":100}]},{"metric":{"quantile":"p99","service":"test2"},"values":[{"timestamp":1695637232,"value":150}]},{"metric":{"quantile":"p95","service":"test3"},"values":[{"timestamp":1695637233,"value":100}]},{"metric":{"quantile":"p99","service":"test3"},"values":[{"timestamp":1695637233,"value":150}]}]}}],"error":{"code":"ERROR_CODE_NO"}}`,
 			wantStatus:   http.StatusOK,
 			cfg: config.SeqAPI{
 				MaxAggregationsPerRequest:  3,
@@ -179,7 +179,7 @@ func TestServeGetAggregationTs(t *testing.T) {
 					PartialResponse: true,
 				},
 			},
-			wantRespBody: `{"aggregations":null,"error":"partial response"}`,
+			wantRespBody: `{"aggregations":null,"error":{"code":"ERROR_CODE_PARTIAL_RESPONSE","message":"partial response"}}`,
 			wantStatus:   http.StatusOK,
 			cfg: config.SeqAPI{
 				MaxAggregationsPerRequest:  3,

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -2398,7 +2398,7 @@
                     }
                 },
                 "error": {
-                    "type": "string"
+                    "$ref": "#/definitions/seqapi.v1.Error"
                 }
             }
         },


### PR DESCRIPTION
# Description

`/aggregation_ts` methon now returns error as object with code and message, like `/aggregation`